### PR TITLE
Check instance is set before use

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -98,7 +98,7 @@ export default {
 
 	watch: {
 		value( val ) {
-			if ( this.instance.getData() !== val ) {
+			if ( this.instance && this.instance.getData() !== val ) {
 				this.instance.setData( val );
 			}
 		},


### PR DESCRIPTION
I ran into a scenario where I was getting a "Cannot read property 'getData' of undefined" error from the watcher because it was trying to set data before `this.instance` had been set.  It looks like this can be reproduced if the component is initialized with a non-empty value or v-model.

Closes #32 