### PR TITLE
Prevent properties updates on uninitialized editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CKEditor 4 WYSIWYG Editor Vue Integration Changelog
 
+## ckeditor4-vue 1.0.0
+
+Fixed issues:
+
+* [#32](https://github.com/ckeditor/ckeditor4-vue/issues/32): Fixed: Watchers may interrupt editor initialization. Thanks to [Michael Babker](https://github.com/mbabker)!
+
 ## ckeditor4-vue 0.2.0
 
 Other Changes:

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -98,13 +98,15 @@ export default {
 
 	watch: {
 		value( val ) {
-			if ( this.instance.getData() !== val ) {
+			if ( this.instance && this.instance.getData() !== val ) {
 				this.instance.setData( val );
 			}
 		},
 
 		readOnly( val ) {
-			this.instance.setReadOnly( val );
+			if ( this.instance ) {
+				this.instance.setReadOnly( val );
+			}
 		}
 	},
 

--- a/tests/component.js
+++ b/tests/component.js
@@ -208,6 +208,34 @@ describe( 'CKEditor Component', () => {
 		} );
 	} );
 
+	describe( 'when watched property changed before editor initialized', () => {
+		beforeEach( () => {
+			skipReady = true;
+			component.instance = null;
+		} );
+
+		describe( 'property', () => {
+			[
+				{
+					property: 'value',
+					value: 'foobar'
+				},
+				{
+					property: 'readOnly',
+					value: true
+				}
+			].forEach( ( { property, value } ) => {
+				it( `"${ property }" should avoid instance operations`, () => {
+					wrapper.setProps( {
+						[ property ]: value
+					} );
+
+					sinon.assert.pass();
+				} );
+			} );
+		} );
+	} );
+
 	// This test might look a bit strange, but it's crucial to run things in proper order.
 	describe( 'when component destroyed before getEditorNamespace resolves', () => {
 		let resolveMockReturnedPromise,


### PR DESCRIPTION
It's a continuation of #25 

Changelog entry:

```
* [#32] Fixed: Watchers may interrupt editor initialization. Thanks [Michael Babker](https://github.com/mbabker)!
```

Closes #32 