### PR TITLE
Allow retranspile ckeditor-integrations-common

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ node_js:
 - '12'
 
 cache:
-- node_modules
+  npm: false
 
 before_install:
 - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ node_js:
 - '12'
 
 cache:
-  npm: false
+- node_modules
 
 before_install:
 - export DISPLAY=:99.0

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -103,6 +103,9 @@ module.exports = function( config ) {
 				browser: 'edge'
 			},
 			BrowserStack_IE11: {
+				base: 'BrowserStack',
+				os: 'Windows',
+				os_version: '10',
 				browser: 'ie',
 				browser_version: '11.0'
 			},

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -102,6 +102,10 @@ module.exports = function( config ) {
 				os_version: '10',
 				browser: 'edge'
 			},
+			BrowserStack_IE11: {
+				browser: 'ie',
+				browser_version: '11.0'
+			},
 			BrowserStack_Safari: {
 				base: 'BrowserStack',
 				os: 'OS X',
@@ -158,6 +162,7 @@ function getBrowsers() {
 			'Chrome',
 			'Firefox',
 			'BrowserStack_Edge',
+			'BrowserStack_IE11',
 			'BrowserStack_Safari'
 		];
 	}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"vue": "^2.5.17"
 	},
 	"dependencies": {
-		"ckeditor4-integrations-common": "2a93ddd18b3f0aee0bc73d6a6bf1d29c01841f54"
+		"ckeditor4-integrations-common": "https://github.com/ckeditor/ckeditor4-integrations-common.git#2a93ddd18b3f0aee0bc73d6a6bf1d29c01841f54"
 	},
 	"engines": {
 		"node": ">=8.0.0",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
 		"samples/"
 	],
 	"devDependencies": {
-		"@babel/core": "^7.11.6",
-		"@babel/preset-env": "^7.11.5",
+		"@babel/core": "^7.12.10",
+		"@babel/preset-env": "^7.12.11",
 		"@vue/test-utils": "^1.0.0-beta.29",
-		"babel-loader": "^8.1.0",
+		"babel-loader": "^8.2.2",
 		"chai": "^4.1.2",
 		"core-js": "^3.8.2",
 		"eslint": "^7.17.0",
@@ -36,8 +36,8 @@
 		"vue": "^2.5.17",
 		"vue-router": "^3.1.3",
 		"vue-template-compiler": "^2.5.17",
-		"webpack": "^4.44.2",
-		"webpack-cli": "^3.3.12"
+		"webpack": "^4.20.2",
+		"webpack-cli": "^4.3.1"
 	},
 	"peerDependencies": {
 		"vue": "^2.5.17"

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
 		"samples/"
 	],
 	"devDependencies": {
-		"@babel/core": "^7.12.10",
-		"@babel/preset-env": "^7.12.11",
+		"@babel/core": "^7.11.6",
+		"@babel/preset-env": "^7.11.5",
 		"@vue/test-utils": "^1.0.0-beta.29",
-		"babel-loader": "^8.2.2",
+		"babel-loader": "^8.1.0",
 		"chai": "^4.1.2",
 		"core-js": "^3.8.2",
 		"eslint": "^7.17.0",
@@ -36,8 +36,8 @@
 		"vue": "^2.5.17",
 		"vue-router": "^3.1.3",
 		"vue-template-compiler": "^2.5.17",
-		"webpack": "^4.20.2",
-		"webpack-cli": "^4.3.1"
+		"webpack": "^4.44.2",
+		"webpack-cli": "^3.3.12"
 	},
 	"peerDependencies": {
 		"vue": "^2.5.17"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"vue": "^2.5.17"
 	},
 	"dependencies": {
-		"ckeditor4-integrations-common": "https://github.com/ckeditor/ckeditor4-integrations-common.git#2a93ddd18b3f0aee0bc73d6a6bf1d29c01841f54"
+		"ckeditor4-integrations-common": "https://github.com/ckeditor/ckeditor4-integrations-common.git#cb95c8fd38c45996a5fefd7a70cec3ea268eb28e"
 	},
 	"engines": {
 		"node": ">=8.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"vue": "^2.5.17"
 	},
 	"dependencies": {
-		"ckeditor4-integrations-common": "^0.1.0"
+		"ckeditor4-integrations-common": "2a93ddd18b3f0aee0bc73d6a6bf1d29c01841f54"
 	},
 	"engines": {
 		"node": ">=8.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,7 +78,7 @@ function createConfig( filename, presets = [] ) {
 				{
 					test: /\.js$/,
 					loader: 'babel-loader',
-					exclude: /node_modules\/(?!(ckeditor4-integrations-common)\/).*/,
+					exclude: /node_modules/,
 					query: {
 						compact: false,
 						presets

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,7 +78,7 @@ function createConfig( filename, presets = [] ) {
 				{
 					test: /\.js$/,
 					loader: 'babel-loader',
-					exclude: /node_modules/,
+					exclude: /node_modules\/(?!(ckeditor4-integrations-common)\/).*/,
 					query: {
 						compact: false,
 						presets


### PR DESCRIPTION
In webpack config, `ckeditor-integrations-common` is now excluded from `exclude` option.

It allows to transpile it in vue integration.

Since IE11 compatibility is a vue integration issue, I decide to not fix this by transpilation of `ckeditor-integrations-common`.

Closes #75