### PR TITLE
Removed obsolete sudo & add missing os option travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+os: linux
 dist: xenial
 
 services:


### PR DESCRIPTION
Remove obsolete `sudo` option

Add missing `os` option with default `linux`

Closes: #84