### PR TITLE
Fix failing tests

### DIFF
--- a/tests/component.js
+++ b/tests/component.js
@@ -398,7 +398,7 @@ describe( 'CKEditor Component', () => {
 	function createComponent( props ) {
 		const fakeParent = window.document.createElement( 'span' );
 
-		props = {...props}
+		props = { ...props }
 
 		if ( props.config ) {
 			props.config.observableParent = fakeParent;

--- a/tests/component.js
+++ b/tests/component.js
@@ -396,8 +396,18 @@ describe( 'CKEditor Component', () => {
 	} );
 
 	function createComponent( props ) {
+		const fakeParent = window.document.createElement( 'span' );
+
+		props = {...props}
+
+		if ( props.config ) {
+			props.config.observableParent = fakeParent;
+		} else {
+			props.config = { observableParent: fakeParent };
+		}
+
 		return mount( CKEditorComponent, {
-			propsData: { ...props },
+			propsData: props,
 			attachToDocument: true
 		} );
 	}

--- a/tests/component.js
+++ b/tests/component.js
@@ -297,7 +297,7 @@ describe( 'CKEditor Component', () => {
 	} );
 
 	// This test might look a bit strange, but it's crucial to run things in proper order.
-	describe.skip( 'when component destroyed before getEditorNamespace resolves', () => {
+	describe( 'when component destroyed before getEditorNamespace resolves', () => {
 		let resolveMockReturnedPromise,
 			resolveMockCalled;
 

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -10,7 +10,7 @@ import CKEditor from '../src/index';
 /* global window */
 
 describe( 'Integration of CKEditor component', () => {
-	const CKEditorNamespace = window.CKEDITOR;
+	// const CKEditorNamespace = window.CKEDITOR;
 	const wrappers = [];
 
 	before( () => {
@@ -24,7 +24,8 @@ describe( 'Integration of CKEditor component', () => {
 			wrapper.destroy();
 		}
 
-		window.CKEDITOR = CKEditorNamespace;
+		deleteCkeditorScripts();
+		// window.CKEDITOR = CKEditorNamespace;
 	} );
 
 	it( 'should initialize classic editor', () => {
@@ -32,7 +33,7 @@ describe( 'Integration of CKEditor component', () => {
 			const editor = component.instance;
 
 			expect( editor.getData() ).to.equal( '<p><strong>foo</strong></p>\n' );
-			expect( editor.elementMode ).to.equal( CKEditorNamespace.ELEMENT_MODE_REPLACE );
+			expect( editor.elementMode ).to.equal( window.CKEDITOR.ELEMENT_MODE_REPLACE );
 		} );
 	} );
 
@@ -41,7 +42,7 @@ describe( 'Integration of CKEditor component', () => {
 			const editor = component.instance;
 
 			expect( editor.getData() ).to.equal( '<p><strong>foo</strong></p>\n' );
-			expect( editor.elementMode ).to.equal( CKEditorNamespace.ELEMENT_MODE_INLINE );
+			expect( editor.elementMode ).to.equal( window.CKEDITOR.ELEMENT_MODE_INLINE );
 		} );
 	} );
 
@@ -54,7 +55,7 @@ describe( 'Integration of CKEditor component', () => {
 	it( 'should call namespace loaded directive only for the initial script load', () => {
 		const spy = sinon.spy();
 
-		deleteCkeditorScripts();
+		// deleteCkeditorScripts();
 
 		return Promise.all( [
 			createComponent( {}, spy ),
@@ -74,7 +75,7 @@ describe( 'Integration of CKEditor component', () => {
 
 		const expectedLang = 'fr';
 
-		deleteCkeditorScripts();
+		// deleteCkeditorScripts();
 
 		return createComponent( {}, changeLang( expectedLang ) ).then( component1 => {
 			expect( component1.instance.config.language ).to.equal( expectedLang );
@@ -90,7 +91,7 @@ describe( 'Integration of CKEditor component', () => {
 	it( 'should use correct CKEDITOR build', () => {
 		const basePath = 'https://cdn.ckeditor.com/4.13.0/standard-all/';
 
-		deleteCkeditorScripts();
+		// deleteCkeditorScripts();
 
 		return createComponent( { editorUrl: basePath + 'ckeditor.js' } ).then( ( comp ) => {
 			expect( window.CKEDITOR.basePath ).to.equal( basePath );

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -92,7 +92,7 @@ describe( 'Integration of CKEditor component', () => {
 
 		deleteCkeditorScripts();
 
-		return createComponent( { editorUrl: basePath + 'ckeditor.js' } ).then( (comp) => {
+		return createComponent( { editorUrl: basePath + 'ckeditor.js' } ).then( ( comp ) => {
 			expect( window.CKEDITOR.basePath ).to.equal( basePath );
 		} );
 	} );
@@ -149,7 +149,7 @@ describe( 'Integration of CKEditor component', () => {
 		const scripts = Array.from( document.querySelectorAll( 'script' ) );
 		const ckeditorScripts = scripts.filter( scriptElement => {
 			return scriptElement.src.indexOf( 'ckeditor.js' ) > -1;
-		});
+		} );
 		ckeditorScripts.forEach( x => x.parentNode.removeChild( x ) );
 
 		delete window.CKEDITOR;

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -7,7 +7,7 @@ import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import CKEditor from '../src/index';
 
-/* global window */
+/* global window, document */
 
 describe( 'Integration of CKEditor component', () => {
 	const wrappers = [];
@@ -34,7 +34,6 @@ describe( 'Integration of CKEditor component', () => {
 			expect( editor.elementMode ).to.equal( window.CKEDITOR.ELEMENT_MODE_REPLACE );
 		} );
 	} );
-
 
 	it( 'should initialize inline editor', () => {
 		return createComponent( { type: 'inline' } ).then( component => {

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -65,7 +65,7 @@ describe( 'Integration of CKEditor component', () => {
 		} );
 	} );
 
-	it.skip( 'should allow modifying global config between editors', () => {
+	it( 'should allow modifying global config between editors', () => {
 		const changeLang = lang => {
 			return ( namespace => {
 				namespace.config.language = lang;

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -51,7 +51,7 @@ describe( 'Integration of CKEditor component', () => {
 		} );
 	} );
 
-	it.skip( 'should call namespace loaded directive only for the initial script load', () => {
+	it( 'should call namespace loaded directive only for the initial script load', () => {
 		const spy = sinon.spy();
 
 		deleteCkeditors();
@@ -100,12 +100,14 @@ describe( 'Integration of CKEditor component', () => {
 	function createComponent( props = {}, namespaceLoaded = ( () => {} ) ) {
 		return new Promise( resolve => {
 			props = propsToString( props );
+			const fakeParent = window.document.createElement( 'span' );
 
 			const wrapper = mount( {
 				template: `
 				<ckeditor
 					v-model="editorData"
 					@namespaceloaded="namespaceLoaded"
+					v-bind:config="cfg"
 					${ props }
 				></ckeditor>`
 			}, {
@@ -115,7 +117,10 @@ describe( 'Integration of CKEditor component', () => {
 				},
 				data: () => {
 					return {
-						editorData: '<p><b>foo</b></p>'
+						editorData: '<p><b>foo</b></p>',
+						cfg: {
+							observableParent: fakeParent
+						}
 					};
 				}
 			} );

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -54,7 +54,7 @@ describe( 'Integration of CKEditor component', () => {
 	it.skip( 'should call namespace loaded directive only for the initial script load', () => {
 		const spy = sinon.spy();
 
-		delete window.CKEDITOR;
+		deleteCkeditors();
 
 		return Promise.all( [
 			createComponent( {}, spy ),
@@ -74,7 +74,7 @@ describe( 'Integration of CKEditor component', () => {
 
 		const expectedLang = 'fr';
 
-		delete window.CKEDITOR;
+		deleteCkeditors();
 
 		return createComponent( {}, changeLang( expectedLang ) ).then( component1 => {
 			expect( component1.instance.config.language ).to.equal( expectedLang );
@@ -90,10 +90,10 @@ describe( 'Integration of CKEditor component', () => {
 	it( 'should use correct CKEDITOR build', () => {
 		const basePath = 'https://cdn.ckeditor.com/4.13.0/standard-all/';
 
-		delete window.CKEDITOR;
+		deleteCkeditors();
 
 		return createComponent( { editorUrl: basePath + 'ckeditor.js' } ).then( (comp) => {
-			expect( comp.instance.config.basePath ).to.equal( basePath );
+			expect( window.CKEDITOR.basePath ).to.equal( basePath );
 		} );
 	} );
 
@@ -138,5 +138,15 @@ describe( 'Integration of CKEditor component', () => {
 		}
 
 		return propsValue;
+	}
+
+	function deleteCkeditors() {
+		const scripts = Array.from( document.querySelectorAll('script') );
+		const ckeditorScripts = scripts.filter( scriptElement => {
+			return scriptElement.src.endsWith('ckeditor.js')
+		});
+		ckeditorScripts.forEach( x => x.remove());
+
+		delete window.CKEDITOR;
 	}
 } );

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -54,7 +54,7 @@ describe( 'Integration of CKEditor component', () => {
 	it( 'should call namespace loaded directive only for the initial script load', () => {
 		const spy = sinon.spy();
 
-		deleteCkeditors();
+		deleteCkeditorScripts();
 
 		return Promise.all( [
 			createComponent( {}, spy ),
@@ -74,7 +74,7 @@ describe( 'Integration of CKEditor component', () => {
 
 		const expectedLang = 'fr';
 
-		deleteCkeditors();
+		deleteCkeditorScripts();
 
 		return createComponent( {}, changeLang( expectedLang ) ).then( component1 => {
 			expect( component1.instance.config.language ).to.equal( expectedLang );
@@ -90,7 +90,7 @@ describe( 'Integration of CKEditor component', () => {
 	it( 'should use correct CKEDITOR build', () => {
 		const basePath = 'https://cdn.ckeditor.com/4.13.0/standard-all/';
 
-		deleteCkeditors();
+		deleteCkeditorScripts();
 
 		return createComponent( { editorUrl: basePath + 'ckeditor.js' } ).then( (comp) => {
 			expect( window.CKEDITOR.basePath ).to.equal( basePath );
@@ -145,12 +145,12 @@ describe( 'Integration of CKEditor component', () => {
 		return propsValue;
 	}
 
-	function deleteCkeditors() {
-		const scripts = Array.from( document.querySelectorAll('script') );
+	function deleteCkeditorScripts() {
+		const scripts = Array.from( document.querySelectorAll( 'script' ) );
 		const ckeditorScripts = scripts.filter( scriptElement => {
-			return scriptElement.src.endsWith('ckeditor.js')
+			return scriptElement.src.indexOf( 'ckeditor.js' ) > -1;
 		});
-		ckeditorScripts.forEach( x => x.remove());
+		ckeditorScripts.forEach( x => x.parentNode.removeChild( x ) );
 
 		delete window.CKEDITOR;
 	}

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -51,16 +51,6 @@ describe( 'Integration of CKEditor component', () => {
 		} );
 	} );
 
-	it.skip( 'should use correct CKEDITOR build', () => {
-		const basePath = 'https://cdn.ckeditor.com/4.13.0/standard-all/';
-
-		delete window.CKEDITOR;
-
-		return createComponent( { editorUrl: basePath + 'ckeditor.js' } ).then( () => {
-			expect( window.CKEDITOR.basePath ).to.equal( basePath );
-		} );
-	} );
-
 	it.skip( 'should call namespace loaded directive only for the initial script load', () => {
 		const spy = sinon.spy();
 
@@ -94,6 +84,16 @@ describe( 'Integration of CKEditor component', () => {
 			return createComponent();
 		} ).then( component3 => {
 			expect( component3.instance.config.language ).to.equal( expectedLang );
+		} );
+	} );
+
+	it( 'should use correct CKEDITOR build', () => {
+		const basePath = 'https://cdn.ckeditor.com/4.13.0/standard-all/';
+
+		delete window.CKEDITOR;
+
+		return createComponent( { editorUrl: basePath + 'ckeditor.js' } ).then( (comp) => {
+			expect( comp.instance.config.basePath ).to.equal( basePath );
 		} );
 	} );
 

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -61,7 +61,7 @@ describe( 'Integration of CKEditor component', () => {
 			createComponent( {}, spy ),
 			createComponent( {}, spy )
 		] ).then( () => {
-			expect( spy.calledOnce ).to.equal( true );
+			expect( spy.callCount ).to.equal( 1 );
 		} );
 	} );
 


### PR DESCRIPTION
First of all, I started with defensive `if` on the fragile `CKEDITOR` in the observer (main repository). However, not all tests passed.

The most damaged makes setup editor from CDN via `editorUrl` props. So I moved it to the last position, so no other tests will fail because of it: https://github.com/ckeditor/ckeditor4-vue/pull/127/commits/844da89a3c6c74bf55e939f300b737e087202ea5

I have a problem with not incoming events from the main editor code, like `ready` and I decided that I change an assertion, so it shows if the event was invoked at all, rather than verify only if it was one time. Because no calls of the spy in the test - means that some event wasn't raised at a deep level, whereas multiple calls tell us about problems in integration commons:  https://github.com/ckeditor/ckeditor4-vue/pull/127/commits/c3fc2a18013ccda70043e80336b00e1f109d6333

Based debug in karma run, I found that the failing test `should use correct CKEDITOR build` try to load some assets from the different origin that it was set via `editorUrl`. And it appears that during the test we are deleting `window.CKEDITOR` but there are still scripts added via 'namespaceloader'. So I decided to remove all `ckeditor.js` scripts-like along with deleting global `window.CKEDITOR`. That fixes the last test assertion problem: https://github.com/ckeditor/ckeditor4-vue/pull/127/commits/fdb6de33630f64aa41dd2d9eaee4aaae30b45444 However, I'm still thinking, that if you load CKE4 from the CDN via `editorUrl` and then, you check `editorInstance.config.basePath` - it's different. It has good parts, but that may be something worth checking with https://github.com/ckeditor/ckeditor4/issues/4761.

I was able to fix the issue with `MutationObserver` in vue tests, thanks to also new config option: https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-observableParent It tells the observer, which node should be checked and in case of changes - determine if there is an CKE4 instance inside. If we provide an immutable element, then observer callback will never be run: https://github.com/ckeditor/ckeditor4-vue/pull/127/commits/a7450096434116fd60324d8528ac615920fb676d

Finally, I have to adjust the code for IE 😢 : https://github.com/ckeditor/ckeditor4-vue/pull/127/commits/9b6de22c96cd1a5759e2fe8787a549afb580ede4

Closes #124 