### PR TITLE
Use delayIfDetached as default value in editor config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CKEditor 4 WYSIWYG Editor Vue Integration Changelog
 
+## ckeditor4-vue 1.5.0
+
+New Features:
+
+* [#102](https://github.com/ckeditor/ckeditor4-vue/issues/102): Use `config.delayIfDetached = true` for editor to support delayed editor's creation upon detached DOM elements.
+
 ## ckeditor4-vue 1.4.0
 
 Highlights:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.14.8",
 				"@babel/preset-env": "^7.14.8",
-				"@vue/test-utils": "1.0.0-beta.33",
+				"@vue/test-utils": "^1.0.4",
 				"babel-loader": "^8.2.2",
 				"chai": "^4.3.4",
 				"core-js": "^3.16.0",
@@ -1781,9 +1781,9 @@
 			"dev": true
 		},
 		"node_modules/@vue/test-utils": {
-			"version": "1.0.0-beta.33",
-			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.33.tgz",
-			"integrity": "sha512-Xzqoe0lTLn3QRWfjhmKPOXYR86l0Y+g/zPHaheJQOkPLj5ojJl3rG0t4F3kXFWuLD88YzUVRMIBWOG7v9KOJQQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.3.0.tgz",
+			"integrity": "sha512-Xk2Xiyj2k5dFb8eYUKkcN9PzqZSppTlx7LaQWBbdA8tqh3jHr/KHX2/YLhNFc/xwDrgeLybqd+4ZCPJSGPIqeA==",
 			"dev": true,
 			"dependencies": {
 				"dom-event-types": "^1.0.0",
@@ -13489,9 +13489,9 @@
 			"dev": true
 		},
 		"@vue/test-utils": {
-			"version": "1.0.0-beta.33",
-			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.33.tgz",
-			"integrity": "sha512-Xzqoe0lTLn3QRWfjhmKPOXYR86l0Y+g/zPHaheJQOkPLj5ojJl3rG0t4F3kXFWuLD88YzUVRMIBWOG7v9KOJQQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.3.0.tgz",
+			"integrity": "sha512-Xk2Xiyj2k5dFb8eYUKkcN9PzqZSppTlx7LaQWBbdA8tqh3jHr/KHX2/YLhNFc/xwDrgeLybqd+4ZCPJSGPIqeA==",
 			"dev": true,
 			"requires": {
 				"dom-event-types": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.14.8",
 				"@babel/preset-env": "^7.14.8",
-				"@vue/test-utils": "1.0.0-beta.30",
+				"@vue/test-utils": "1.0.0-beta.31",
 				"babel-loader": "^8.2.2",
 				"chai": "^4.3.4",
 				"core-js": "^3.16.0",
@@ -1781,9 +1781,9 @@
 			"dev": true
 		},
 		"node_modules/@vue/test-utils": {
-			"version": "1.0.0-beta.30",
-			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.30.tgz",
-			"integrity": "sha512-Wyvcha9fNk8+kzTDwb3xWGjPkCPzHSYSwKP6MplrPTG/auhqoad7JqUEceZLc6u7AU4km2pPQ8/m9s0RgCZ0NA==",
+			"version": "1.0.0-beta.31",
+			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.31.tgz",
+			"integrity": "sha512-IlhSx5hyEVnbvDZ3P98R1jNmy88QAd/y66Upn4EcvxSD5D4hwOutl3dIdfmSTSXs4b9DIMDnEVjX7t00cvOnvg==",
 			"dev": true,
 			"dependencies": {
 				"dom-event-types": "^1.0.0",
@@ -13489,9 +13489,9 @@
 			"dev": true
 		},
 		"@vue/test-utils": {
-			"version": "1.0.0-beta.30",
-			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.30.tgz",
-			"integrity": "sha512-Wyvcha9fNk8+kzTDwb3xWGjPkCPzHSYSwKP6MplrPTG/auhqoad7JqUEceZLc6u7AU4km2pPQ8/m9s0RgCZ0NA==",
+			"version": "1.0.0-beta.31",
+			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.31.tgz",
+			"integrity": "sha512-IlhSx5hyEVnbvDZ3P98R1jNmy88QAd/y66Upn4EcvxSD5D4hwOutl3dIdfmSTSXs4b9DIMDnEVjX7t00cvOnvg==",
 			"dev": true,
 			"requires": {
 				"dom-event-types": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.14.8",
 				"@babel/preset-env": "^7.14.8",
-				"@vue/test-utils": "1.0.0-beta.29",
+				"@vue/test-utils": "1.0.0-beta.30",
 				"babel-loader": "^8.2.2",
 				"chai": "^4.3.4",
 				"core-js": "^3.16.0",
@@ -1781,13 +1781,14 @@
 			"dev": true
 		},
 		"node_modules/@vue/test-utils": {
-			"version": "1.0.0-beta.29",
-			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.29.tgz",
-			"integrity": "sha512-yX4sxEIHh4M9yAbLA/ikpEnGKMNBCnoX98xE1RwxfhQVcn0MaXNSj1Qmac+ZydTj6VBSEVukchBogXBTwc+9iA==",
+			"version": "1.0.0-beta.30",
+			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.30.tgz",
+			"integrity": "sha512-Wyvcha9fNk8+kzTDwb3xWGjPkCPzHSYSwKP6MplrPTG/auhqoad7JqUEceZLc6u7AU4km2pPQ8/m9s0RgCZ0NA==",
 			"dev": true,
 			"dependencies": {
 				"dom-event-types": "^1.0.0",
-				"lodash": "^4.17.4"
+				"lodash": "^4.17.15",
+				"pretty": "^2.0.0"
 			},
 			"peerDependencies": {
 				"vue": "2.x",
@@ -2015,6 +2016,12 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+			"dev": true
+		},
+		"node_modules/abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
 		"node_modules/accepts": {
@@ -3533,6 +3540,54 @@
 				"typedarray": "^0.0.6"
 			}
 		},
+		"node_modules/condense-newlines": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz",
+			"integrity": "sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=",
+			"dev": true,
+			"dependencies": {
+				"extend-shallow": "^2.0.1",
+				"is-whitespace": "^0.3.0",
+				"kind-of": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/condense-newlines/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/condense-newlines/node_modules/kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"dependencies": {
+				"is-buffer": "^1.1.5"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/config-chain": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+			"dev": true,
+			"dependencies": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
+		},
 		"node_modules/connect": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
@@ -4091,6 +4146,37 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
+		},
+		"node_modules/editorconfig": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+			"dev": true,
+			"dependencies": {
+				"commander": "^2.19.0",
+				"lru-cache": "^4.1.5",
+				"semver": "^5.6.0",
+				"sigmund": "^1.0.1"
+			},
+			"bin": {
+				"editorconfig": "bin/editorconfig"
+			}
+		},
+		"node_modules/editorconfig/node_modules/lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"dev": true,
+			"dependencies": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"node_modules/editorconfig/node_modules/yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
@@ -5890,6 +5976,12 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
+		},
 		"node_modules/interpret": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
@@ -6199,6 +6291,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-whitespace": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
+			"integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -6456,6 +6557,26 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/js-beautify": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.0.tgz",
+			"integrity": "sha512-yuck9KirNSCAwyNJbqW+BxJqJ0NLJ4PwBUzQQACl5O3qHMBXVkXb/rD0ilh/Lat/tn88zSZ+CAHOlk0DsY7GuQ==",
+			"dev": true,
+			"dependencies": {
+				"config-chain": "^1.1.12",
+				"editorconfig": "^0.15.3",
+				"glob": "^7.1.3",
+				"nopt": "^5.0.0"
+			},
+			"bin": {
+				"css-beautify": "js/bin/css-beautify.js",
+				"html-beautify": "js/bin/html-beautify.js",
+				"js-beautify": "js/bin/js-beautify.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/js-tokens": {
@@ -8282,6 +8403,21 @@
 			"integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
 			"dev": true
 		},
+		"node_modules/nopt": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+			"dev": true,
+			"dependencies": {
+				"abbrev": "1"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -8783,6 +8919,32 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/pretty": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
+			"integrity": "sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=",
+			"dev": true,
+			"dependencies": {
+				"condense-newlines": "^0.2.1",
+				"extend-shallow": "^2.0.1",
+				"js-beautify": "^1.6.12"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pretty/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -8811,6 +8973,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
 			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+			"dev": true
+		},
+		"node_modules/proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 			"dev": true
 		},
 		"node_modules/proxy-middleware": {
@@ -8842,6 +9010,12 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
+		},
+		"node_modules/pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"node_modules/psl": {
 			"version": "1.8.0",
@@ -9642,6 +9816,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/sigmund": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"dev": true
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.3",
@@ -13309,13 +13489,14 @@
 			"dev": true
 		},
 		"@vue/test-utils": {
-			"version": "1.0.0-beta.29",
-			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.29.tgz",
-			"integrity": "sha512-yX4sxEIHh4M9yAbLA/ikpEnGKMNBCnoX98xE1RwxfhQVcn0MaXNSj1Qmac+ZydTj6VBSEVukchBogXBTwc+9iA==",
+			"version": "1.0.0-beta.30",
+			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.30.tgz",
+			"integrity": "sha512-Wyvcha9fNk8+kzTDwb3xWGjPkCPzHSYSwKP6MplrPTG/auhqoad7JqUEceZLc6u7AU4km2pPQ8/m9s0RgCZ0NA==",
 			"dev": true,
 			"requires": {
 				"dom-event-types": "^1.0.0",
-				"lodash": "^4.17.4"
+				"lodash": "^4.17.15",
+				"pretty": "^2.0.0"
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -13526,6 +13707,12 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+			"dev": true
+		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
 		"accepts": {
@@ -14774,6 +14961,47 @@
 				"typedarray": "^0.0.6"
 			}
 		},
+		"condense-newlines": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz",
+			"integrity": "sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-whitespace": "^0.3.0",
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"config-chain": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+			"dev": true,
+			"requires": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
+		},
 		"connect": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
@@ -15241,6 +15469,36 @@
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
+			}
+		},
+		"editorconfig": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+			"dev": true,
+			"requires": {
+				"commander": "^2.19.0",
+				"lru-cache": "^4.1.5",
+				"semver": "^5.6.0",
+				"sigmund": "^1.0.1"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"dev": true
+				}
 			}
 		},
 		"ee-first": {
@@ -16651,6 +16909,12 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
+		},
 		"interpret": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
@@ -16879,6 +17143,12 @@
 			"integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
 			"dev": true
 		},
+		"is-whitespace": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
+			"integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38=",
+			"dev": true
+		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -17087,6 +17357,18 @@
 						"has-flag": "^4.0.0"
 					}
 				}
+			}
+		},
+		"js-beautify": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.0.tgz",
+			"integrity": "sha512-yuck9KirNSCAwyNJbqW+BxJqJ0NLJ4PwBUzQQACl5O3qHMBXVkXb/rD0ilh/Lat/tn88zSZ+CAHOlk0DsY7GuQ==",
+			"dev": true,
+			"requires": {
+				"config-chain": "^1.1.12",
+				"editorconfig": "^0.15.3",
+				"glob": "^7.1.3",
+				"nopt": "^5.0.0"
 			}
 		},
 		"js-tokens": {
@@ -18566,6 +18848,15 @@
 			"integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
 			"dev": true
 		},
+		"nopt": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+			"dev": true,
+			"requires": {
+				"abbrev": "1"
+			}
+		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -18952,6 +19243,28 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true
 		},
+		"pretty": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
+			"integrity": "sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=",
+			"dev": true,
+			"requires": {
+				"condense-newlines": "^0.2.1",
+				"extend-shallow": "^2.0.1",
+				"js-beautify": "^1.6.12"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -18976,6 +19289,12 @@
 			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
 			"dev": true
 		},
+		"proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+			"dev": true
+		},
 		"proxy-middleware": {
 			"version": "0.15.0",
 			"resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
@@ -18996,6 +19315,12 @@
 			"requires": {
 				"event-stream": "=3.3.4"
 			}
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"psl": {
 			"version": "1.8.0",
@@ -19659,6 +19984,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true
+		},
+		"sigmund": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
 			"dev": true
 		},
 		"signal-exit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"karma-firefox-launcher": "^2.1.1",
 				"karma-mocha": "^2.0.1",
 				"karma-mocha-reporter": "^2.2.4",
+				"karma-safari-launcher": "^1.0.0",
 				"karma-sinon": "^1.0.5",
 				"karma-sourcemap-loader": "^0.3.8",
 				"karma-webpack": "^4.0.2",
@@ -6889,6 +6890,15 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/karma-safari-launcher": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
+			"integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
+			"dev": true,
+			"peerDependencies": {
+				"karma": ">=0.9"
+			}
+		},
 		"node_modules/karma-sinon": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/karma-sinon/-/karma-sinon-1.0.5.tgz",
@@ -7191,6 +7201,21 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/live-server/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/live-server/node_modules/debug/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
 		"node_modules/live-server/node_modules/extend-shallow": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -7259,6 +7284,22 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/live-server/node_modules/http-errors": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+			"dev": true,
+			"dependencies": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/live-server/node_modules/is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -7283,6 +7324,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/live-server/node_modules/is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/live-server/node_modules/kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -7295,6 +7345,24 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/live-server/node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true,
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/live-server/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true
+		},
 		"node_modules/live-server/node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7302,6 +7370,28 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/live-server/node_modules/opn": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+			"integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
+			"deprecated": "The package has been renamed to `open`",
+			"dev": true,
+			"dependencies": {
+				"is-wsl": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/live-server/node_modules/proxy-middleware": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
+			"integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/live-server/node_modules/readdirp": {
@@ -7318,6 +7408,36 @@
 				"node": ">=0.10"
 			}
 		},
+		"node_modules/live-server/node_modules/send": {
+			"version": "0.17.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
+			"integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+			"dev": true,
+			"dependencies": {
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "1.8.1",
+				"mime": "1.6.0",
+				"ms": "2.1.3",
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.1",
+				"statuses": "~1.5.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/live-server/node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"dev": true
+		},
 		"node_modules/live-server/node_modules/to-regex-range": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
@@ -7329,6 +7449,15 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/live-server/node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.6"
 			}
 		},
 		"node_modules/loader-runner": {
@@ -8603,28 +8732,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/opn": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
-			"integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
-			"deprecated": "The package has been renamed to `open`",
-			"dev": true,
-			"dependencies": {
-				"is-wsl": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/opn/node_modules/is-wsl": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/optionator": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -8980,15 +9087,6 @@
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 			"dev": true
-		},
-		"node_modules/proxy-middleware": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
-			"integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
 		},
 		"node_modules/prr": {
 			"version": "1.0.1",
@@ -9605,63 +9703,6 @@
 			"bin": {
 				"semver": "bin/semver"
 			}
-		},
-		"node_modules/send": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-			"dev": true,
-			"dependencies": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.7.2",
-				"mime": "1.6.0",
-				"ms": "2.1.1",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.1",
-				"statuses": "~1.5.0"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/send/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/send/node_modules/debug/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
-		},
-		"node_modules/send/node_modules/mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"dev": true,
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/send/node_modules/ms": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-			"dev": true
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.0",
@@ -17667,6 +17708,13 @@
 				}
 			}
 		},
+		"karma-safari-launcher": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
+			"integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
+			"dev": true,
+			"requires": {}
+		},
 		"karma-sinon": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/karma-sinon/-/karma-sinon-1.0.5.tgz",
@@ -17869,6 +17917,23 @@
 						"vary": "^1"
 					}
 				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"dev": true
+						}
+					}
+				},
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -17922,6 +17987,19 @@
 						}
 					}
 				},
+				"http-errors": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+					"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+					"dev": true,
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.4",
+						"setprototypeof": "1.2.0",
+						"statuses": ">= 1.5.0 < 2",
+						"toidentifier": "1.0.1"
+					}
+				},
 				"is-binary-path": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -17940,6 +18018,12 @@
 						"kind-of": "^3.0.2"
 					}
 				},
+				"is-wsl": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+					"dev": true
+				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -17949,10 +18033,37 @@
 						"is-buffer": "^1.1.5"
 					}
 				},
+				"mime": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+					"dev": true
+				},
 				"object-assign": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"dev": true
+				},
+				"opn": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+					"integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
+					"dev": true,
+					"requires": {
+						"is-wsl": "^1.1.0"
+					}
+				},
+				"proxy-middleware": {
+					"version": "0.15.0",
+					"resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
+					"integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
 					"dev": true
 				},
 				"readdirp": {
@@ -17966,6 +18077,33 @@
 						"readable-stream": "^2.0.2"
 					}
 				},
+				"send": {
+					"version": "0.17.2",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
+					"integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+					"dev": true,
+					"requires": {
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"destroy": "~1.0.4",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
+						"fresh": "0.5.2",
+						"http-errors": "1.8.1",
+						"mime": "1.6.0",
+						"ms": "2.1.3",
+						"on-finished": "~2.3.0",
+						"range-parser": "~1.2.1",
+						"statuses": "~1.5.0"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+					"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+					"dev": true
+				},
 				"to-regex-range": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
@@ -17975,6 +18113,12 @@
 						"is-number": "^3.0.0",
 						"repeat-string": "^1.6.1"
 					}
+				},
+				"toidentifier": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+					"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+					"dev": true
 				}
 			}
 		},
@@ -18993,23 +19137,6 @@
 				"mimic-fn": "^2.1.0"
 			}
 		},
-		"opn": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
-			"integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
-			"dev": true,
-			"requires": {
-				"is-wsl": "^1.1.0"
-			},
-			"dependencies": {
-				"is-wsl": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-					"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-					"dev": true
-				}
-			}
-		},
 		"optionator": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -19293,12 +19420,6 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-			"dev": true
-		},
-		"proxy-middleware": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
-			"integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
 			"dev": true
 		},
 		"prr": {
@@ -19799,58 +19920,6 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"dev": true
-		},
-		"send": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-			"dev": true,
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.7.2",
-				"mime": "1.6.0",
-				"ms": "2.1.1",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.1",
-				"statuses": "~1.5.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						}
-					}
-				},
-				"mime": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				}
-			}
 		},
 		"serialize-javascript": {
 			"version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
 				"karma-firefox-launcher": "^2.1.1",
 				"karma-mocha": "^2.0.1",
 				"karma-mocha-reporter": "^2.2.4",
-				"karma-safari-launcher": "^1.0.0",
 				"karma-sinon": "^1.0.5",
 				"karma-sourcemap-loader": "^0.3.8",
 				"karma-webpack": "^4.0.2",
@@ -6888,15 +6887,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/karma-safari-launcher": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
-			"integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
-			"dev": true,
-			"peerDependencies": {
-				"karma": ">=0.9"
 			}
 		},
 		"node_modules/karma-sinon": {
@@ -17707,13 +17697,6 @@
 					}
 				}
 			}
-		},
-		"karma-safari-launcher": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
-			"integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
-			"dev": true,
-			"requires": {}
 		},
 		"karma-sinon": {
 			"version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.14.8",
 				"@babel/preset-env": "^7.14.8",
-				"@vue/test-utils": "1.0.0-beta.32",
+				"@vue/test-utils": "1.0.0-beta.33",
 				"babel-loader": "^8.2.2",
 				"chai": "^4.3.4",
 				"core-js": "^3.16.0",
@@ -1781,9 +1781,9 @@
 			"dev": true
 		},
 		"node_modules/@vue/test-utils": {
-			"version": "1.0.0-beta.32",
-			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.32.tgz",
-			"integrity": "sha512-ywhe7PATMAk/ZGdsrcuQIliQusOyfe0OOHjKKCCERqgHh1g/kqPtmSMT5Jx4sErx53SYbNucr8QOK6/u5ianAw==",
+			"version": "1.0.0-beta.33",
+			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.33.tgz",
+			"integrity": "sha512-Xzqoe0lTLn3QRWfjhmKPOXYR86l0Y+g/zPHaheJQOkPLj5ojJl3rG0t4F3kXFWuLD88YzUVRMIBWOG7v9KOJQQ==",
 			"dev": true,
 			"dependencies": {
 				"dom-event-types": "^1.0.0",
@@ -13489,9 +13489,9 @@
 			"dev": true
 		},
 		"@vue/test-utils": {
-			"version": "1.0.0-beta.32",
-			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.32.tgz",
-			"integrity": "sha512-ywhe7PATMAk/ZGdsrcuQIliQusOyfe0OOHjKKCCERqgHh1g/kqPtmSMT5Jx4sErx53SYbNucr8QOK6/u5ianAw==",
+			"version": "1.0.0-beta.33",
+			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.33.tgz",
+			"integrity": "sha512-Xzqoe0lTLn3QRWfjhmKPOXYR86l0Y+g/zPHaheJQOkPLj5ojJl3rG0t4F3kXFWuLD88YzUVRMIBWOG7v9KOJQQ==",
 			"dev": true,
 			"requires": {
 				"dom-event-types": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.14.8",
 				"@babel/preset-env": "^7.14.8",
-				"@vue/test-utils": "1.0.0-beta.31",
+				"@vue/test-utils": "1.0.0-beta.32",
 				"babel-loader": "^8.2.2",
 				"chai": "^4.3.4",
 				"core-js": "^3.16.0",
@@ -1781,9 +1781,9 @@
 			"dev": true
 		},
 		"node_modules/@vue/test-utils": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.31.tgz",
-			"integrity": "sha512-IlhSx5hyEVnbvDZ3P98R1jNmy88QAd/y66Upn4EcvxSD5D4hwOutl3dIdfmSTSXs4b9DIMDnEVjX7t00cvOnvg==",
+			"version": "1.0.0-beta.32",
+			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.32.tgz",
+			"integrity": "sha512-ywhe7PATMAk/ZGdsrcuQIliQusOyfe0OOHjKKCCERqgHh1g/kqPtmSMT5Jx4sErx53SYbNucr8QOK6/u5ianAw==",
 			"dev": true,
 			"dependencies": {
 				"dom-event-types": "^1.0.0",
@@ -13489,9 +13489,9 @@
 			"dev": true
 		},
 		"@vue/test-utils": {
-			"version": "1.0.0-beta.31",
-			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.31.tgz",
-			"integrity": "sha512-IlhSx5hyEVnbvDZ3P98R1jNmy88QAd/y66Upn4EcvxSD5D4hwOutl3dIdfmSTSXs4b9DIMDnEVjX7t00cvOnvg==",
+			"version": "1.0.0-beta.32",
+			"resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.32.tgz",
+			"integrity": "sha512-ywhe7PATMAk/ZGdsrcuQIliQusOyfe0OOHjKKCCERqgHh1g/kqPtmSMT5Jx4sErx53SYbNucr8QOK6/u5ianAw==",
 			"dev": true,
 			"requires": {
 				"dom-event-types": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.14.8",
 		"@babel/preset-env": "^7.14.8",
-		"@vue/test-utils": "1.0.0-beta.29",
+		"@vue/test-utils": "1.0.0-beta.30",
 		"babel-loader": "^8.2.2",
 		"chai": "^4.3.4",
 		"core-js": "^3.16.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.14.8",
 		"@babel/preset-env": "^7.14.8",
-		"@vue/test-utils": "1.0.0-beta.30",
+		"@vue/test-utils": "1.0.0-beta.31",
 		"babel-loader": "^8.2.2",
 		"chai": "^4.3.4",
 		"core-js": "^3.16.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"karma-firefox-launcher": "^2.1.1",
 		"karma-mocha": "^2.0.1",
 		"karma-mocha-reporter": "^2.2.4",
+		"karma-safari-launcher": "^1.0.0",
 		"karma-sinon": "^1.0.5",
 		"karma-sourcemap-loader": "^0.3.8",
 		"karma-webpack": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.14.8",
 		"@babel/preset-env": "^7.14.8",
-		"@vue/test-utils": "1.0.0-beta.32",
+		"@vue/test-utils": "1.0.0-beta.33",
 		"babel-loader": "^8.2.2",
 		"chai": "^4.3.4",
 		"core-js": "^3.16.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 		"karma-firefox-launcher": "^2.1.1",
 		"karma-mocha": "^2.0.1",
 		"karma-mocha-reporter": "^2.2.4",
-		"karma-safari-launcher": "^1.0.0",
 		"karma-sinon": "^1.0.5",
 		"karma-sourcemap-loader": "^0.3.8",
 		"karma-webpack": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.14.8",
 		"@babel/preset-env": "^7.14.8",
-		"@vue/test-utils": "1.0.0-beta.33",
+		"@vue/test-utils": "^1.0.4",
 		"babel-loader": "^8.2.2",
 		"chai": "^4.3.4",
 		"core-js": "^3.16.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.14.8",
 		"@babel/preset-env": "^7.14.8",
-		"@vue/test-utils": "1.0.0-beta.31",
+		"@vue/test-utils": "1.0.0-beta.32",
 		"babel-loader": "^8.2.2",
 		"chai": "^4.3.4",
 		"core-js": "^3.16.0",

--- a/samples/index.html
+++ b/samples/index.html
@@ -39,6 +39,7 @@
 		<li class="route__list-item"><router-link to="/types">Editor types</router-link></li>
 		<li class="route__list-item"><router-link to="/events">Component events</router-link></li>
 		<li class="route__list-item"><router-link to="/binding">Two-way binding</router-link></li>
+		<li class="route__list-item"><router-link to="/delayed">Delayed creation</router-link></li>
 		</ul>
 
 		<router-view></router-view>
@@ -134,6 +135,11 @@
 				Note that the <code class="highlight">textarea</code> element is synced after the <code class="highlight">change</code> event. Blur to see content updates.
 			</p>
 			<textarea rows="15" cols="50" v-model.lazy="editorData"></textarea>
+		</main>
+	</script>
+	<script type="text/x-template" id="delayed-creation">
+		<main>
+			<h2>Editor delayed creation</h2>
 		</main>
 	</script>
 

--- a/samples/index.html
+++ b/samples/index.html
@@ -140,6 +140,18 @@
 	<script type="text/x-template" id="delayed-creation">
 		<main>
 			<h2>Editor delayed creation</h2>
+			<p>
+				Please take a look at developers console. It shows `editor-delayed-creation.` since the editor component is mounted, but on detached element.
+			</p>
+			<button @click="attachAgain">ATTACH</button>
+			<p v-if="attached">
+				And now the `editor-delayed-creation-success` appears. It tells that the editor was created with the delayed creation logic.
+			</p>
+			<div id="delayed-editor-container">
+				<div id="delayed-editor-target">
+					<ckeditor></ckeditor>
+				</div>
+			</div>
 		</main>
 	</script>
 

--- a/samples/main.js
+++ b/samples/main.js
@@ -80,6 +80,17 @@ var TwoWayBindingComponent = {
 	}
 };
 
+var DelayedCreationComponent = {
+	name:'delayed-creation',
+	template: '#delayed-creation',
+	mixins: [ defaultMixin ],
+	data: function() {
+		return {
+			editorData: 'Check out how two-way data binding works.'
+		};
+	}
+}
+
 var routes = [
 	{
 		path: '/types',
@@ -90,6 +101,9 @@ var routes = [
 	}, {
 		path: '/binding',
 		component: TwoWayBindingComponent
+	}, {
+		path: '/delayed',
+		component: DelayedCreationComponent
 	},
 	{
 		path: '*',

--- a/samples/main.js
+++ b/samples/main.js
@@ -86,8 +86,21 @@ var DelayedCreationComponent = {
 	mixins: [ defaultMixin ],
 	data: function() {
 		return {
-			editorData: 'Check out how two-way data binding works.'
+			editorContainer: null,
+			editorTarget: null,
+			attached: false
 		};
+	},
+	mounted(){
+		this.editorContainer = document.getElementById( 'delayed-editor-container' );
+		this.editorTarget = document.getElementById( 'delayed-editor-target' );
+		this.editorContainer.removeChild( this.editorTarget );
+	},
+	methods: {
+		attachAgain() {
+			this.editorContainer.appendChild( this.editorTarget );
+			this.attached = true;
+		}
 	}
 }
 

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -98,10 +98,7 @@ export default {
 				config.readOnly = this.readOnly;
 			}
 
-			let userInstanceReadyCallback;
-			if ( config.on && config.on.instanceReady ) {
-				userInstanceReadyCallback = config.on.instanceReady;
-			}
+			const userInstanceReadyCallback = config.on.instanceReady;
 
 			config.on.instanceReady = evt => {
 				this.instance = evt.editor;

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -60,7 +60,7 @@ export default {
 			const method = this.type === 'inline' ? 'inline' : 'replace';
 			const element = this.$el.firstElementChild;
 
-			this.instance = CKEDITOR[ method ]( element, config );
+			CKEDITOR[ method ]( element, config );
 		} );
 	},
 

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -55,58 +55,11 @@ export default {
 			if ( this.$_destroyed ) {
 				return;
 			}
-			const config = this.config || {};
-			if ( config.delayIfDetached === undefined ) {
-				config.delayIfDetached = true;
-			}
-			if ( this.readOnly !== null ) {
-				config.readOnly = this.readOnly;
-			}
 
+			const config = this.prepareConfig();
 			const method = this.type === 'inline' ? 'inline' : 'replace';
 			const element = this.$el.firstElementChild;
-			// console.log( '#'.repeat( 999 ) );
-			// console.log( config.on );
-			// console.log( config.on.instanceReady );
-			let instanceReadyCallback;
-			if ( config.on && config.on.instanceReady ) {
-				instanceReadyCallback = config.on.instanceReady;
-			}
-			config.on = {
-				// TODO cache somewhere oninstance ready?
-				instanceReady: evt => {
-					if ( instanceReadyCallback ) {
-						instanceReadyCallback( evt );
-					}
-					const createdEditor = evt.editor;
-					this.instance = createdEditor;
-					this.$nextTick().then( () => {
-						const data = this.value;
 
-						createdEditor.fire( 'lockSnapshot' );
-
-						createdEditor.setData( data, { callback: () => {
-							this.$_setUpEditorEvents();
-
-							const newData = createdEditor.getData();
-
-							// Locking the snapshot prevents the 'change' event.
-							// Trigger it manually to update the bound data.
-							if ( data !== newData ) {
-								this.$once( 'input', () => {
-									this.$emit( 'ready', createdEditor );
-								} );
-
-								this.$emit( 'input', newData );
-							} else {
-								this.$emit( 'ready', createdEditor );
-							}
-
-							createdEditor.fire( 'unlockSnapshot' );
-						} } );
-					} );
-				}
-			};
 			this.instance = CKEDITOR[ method ]( element, config );
 		} );
 	},
@@ -134,6 +87,61 @@ export default {
 	},
 
 	methods: {
+		prepareConfig() {
+			const config = this.config || {};
+			config.on = config.on || {};
+
+			if ( config.delayIfDetached === undefined ) {
+				config.delayIfDetached = true;
+			}
+			if ( this.readOnly !== null ) {
+				config.readOnly = this.readOnly;
+			}
+
+			let userInstanceReadyCallback;
+			if ( config.on && config.on.instanceReady ) {
+				userInstanceReadyCallback = config.on.instanceReady;
+			}
+
+			config.on.instanceReady = evt => {
+				this.instance = evt.editor;
+
+				this.$nextTick().then( () => {
+					this.prepareComponentData();
+
+					if ( userInstanceReadyCallback ) {
+						userInstanceReadyCallback( evt );
+					}
+				} );
+			};
+
+			return config;
+		},
+		prepareComponentData() {
+			const data = this.value;
+
+			this.instance.fire( 'lockSnapshot' );
+
+			this.instance.setData( data, { callback: () => {
+				this.$_setUpEditorEvents();
+
+				const newData = this.instance.getData();
+
+				// Locking the snapshot prevents the 'change' event.
+				// Trigger it manually to update the bound data.
+				if ( data !== newData ) {
+					this.$once( 'input', () => {
+						this.$emit( 'ready', this.instance );
+					} );
+
+					this.$emit( 'input', newData );
+				} else {
+					this.$emit( 'ready', this.instance );
+				}
+
+				this.instance.fire( 'unlockSnapshot' );
+			} } );
+		},
 		$_setUpEditorEvents() {
 			const editor = this.instance;
 

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -65,8 +65,19 @@ export default {
 
 			const method = this.type === 'inline' ? 'inline' : 'replace';
 			const element = this.$el.firstElementChild;
+			// console.log( '#'.repeat( 999 ) );
+			// console.log( config.on );
+			// console.log( config.on.instanceReady );
+			let instanceReadyCallback;
+			if ( config.on && config.on.instanceReady ) {
+				instanceReadyCallback = config.on.instanceReady;
+			}
 			config.on = {
+				// TODO cache somewhere oninstance ready?
 				instanceReady: evt => {
+					if ( instanceReadyCallback ) {
+						instanceReadyCallback( evt );
+					}
 					const createdEditor = evt.editor;
 					this.instance = createdEditor;
 					this.$nextTick().then( () => {

--- a/tests/component.js
+++ b/tests/component.js
@@ -3,13 +3,13 @@
  * For licensing, see LICENSE.md.
  */
 
+// VTU use entries, which fails for IE11
 import 'core-js/es/object/entries';
+import sinon from 'sinon';
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';
-import CKEditorComponent from '../src/ckeditor';
-import sinon from 'sinon';
 import { getEditorNamespace } from 'ckeditor4-integrations-common';
-
+import CKEditorComponent from '../src/ckeditor';
 import { delay, deleteCkeditorScripts } from './utils';
 
 /* global window, document */
@@ -318,12 +318,12 @@ describe( 'CKEditor Component', () => {
 		before( () => {
 			skipReady = true;
 
-			delete window.CKEDITOR;
-
 			getEditorNamespace.scriptLoader = () => {
 				resolveMockCalled();
 				return mockReturnedPromise;
 			};
+
+			return deleteCkeditorScripts();
 		} );
 
 		// When component is created.

--- a/tests/component.js
+++ b/tests/component.js
@@ -479,7 +479,7 @@ describe( 'component on detached element', () => {
 } );
 
 function createComponent( props, mountTarget = document.body ) {
-	const fakeParent = window.document.createElement( 'span' );
+	const fakeParent = document.createElement( 'span' );
 
 	props = { ...props };
 

--- a/tests/component.js
+++ b/tests/component.js
@@ -293,7 +293,9 @@ describe( 'CKEditor Component', () => {
 						[ property ]: value
 					} );
 
-					sinon.assert.pass();
+					return Vue.nextTick().then( () => {
+						sinon.assert.pass();
+					} );
 				} );
 			} );
 		} );

--- a/tests/component.js
+++ b/tests/component.js
@@ -10,7 +10,7 @@ import CKEditorComponent from '../src/ckeditor';
 import sinon from 'sinon';
 import { getEditorNamespace } from 'ckeditor4-integrations-common';
 
-import { deleteCkeditorScripts } from './utils';
+import { delay, deleteCkeditorScripts } from './utils';
 
 /* global window, document */
 
@@ -475,15 +475,6 @@ describe( 'comp on detach elem', () => {
 		} );
 	} );
 } );
-
-function delay( time, func = () => {} ) {
-	return new Promise( res => {
-		setTimeout( () => {
-			func();
-			res();
-		}, time );
-	} );
-}
 
 function createComponent( props, mountTarget = document.body ) {
 	const fakeParent = window.document.createElement( 'span' );

--- a/tests/component.js
+++ b/tests/component.js
@@ -435,7 +435,7 @@ describe( 'comp on detach elem', () => {
 		return delay( 100, () => {
 			// Editor is created after namespace loads
 			// so we need to wait for the real results
-			expect( wrapperr.vm.instance ).to.be.null;
+			expect( wrapperr.vm.instance ).to.be.undefined;
 		} ).then( () => {
 			document.body.appendChild( parent );
 		} ).then( () => {
@@ -466,7 +466,7 @@ describe( 'comp on detach elem', () => {
 		return delay( 100, () => {
 			// Editor is created after namespace loads
 			// so we need to wait for the real results
-			expect( wrapperr.vm.instance ).to.be.null;
+			expect( wrapperr.vm.instance ).to.be.undefined;
 		} ).then( () => {
 			document.body.appendChild( parent );
 			createEditor();

--- a/tests/component.js
+++ b/tests/component.js
@@ -410,14 +410,15 @@ describe.skip( 'CKEditor Component', () => {
 
 describe( 'comp on detach elem', () => {
 	let wrapper;
-	const cken = window.CKEDITOR;
-	const sandbox = sinon.createSandbox();
-	sandbox.spy( cken, 'replace' );
+	// const cken = window.CKEDITOR;
+	// const sandbox = sinon.createSandbox();
+	// sandbox.spy( cken, 'replace' );
 
 	afterEach( () => {
 		wrapper.destroy();
-		sandbox.restore();
+		// sandbox.restore();
 	} );
+
 	it( 'tries to mount component on detached element and use default interval strategy before creates', () => {
 		const parent = document.createElement( 'div' );
 		// Vue will replace mount target, so we have extra parent to manipulate it.
@@ -425,11 +426,7 @@ describe( 'comp on detach elem', () => {
 		parent.appendChild( mountTarget );
 
 		wrapper = mount( CKEditorComponent, {
-			propsData: {
-				// 		config: {
-				// 			// delayIfDetached: tre
-				// 		}
-			},
+			propsData: {},
 			attachTo: mountTarget
 		} );
 		// const component = wrapper.vm.$children[ 0 ];
@@ -441,7 +438,37 @@ describe( 'comp on detach elem', () => {
 		} ).then( () => {
 			document.body.appendChild( parent );
 		} ).then( () => {
-			return delay( 1000 );
+			return delay( 1000, () => {
+				expect( wrapper.vm.instance ).to.be.not.null;
+			} );
+		} );
+	} );
+
+	it( 'tries to mount component on detached element and use callback strategy', () => {
+		const parent = document.createElement( 'div' );
+		// Vue will replace mount target, so we have extra parent to manipulate it.
+		const mountTarget = document.createElement( 'div' );
+		parent.appendChild( mountTarget );
+		let fcreat;
+		wrapper = mount( CKEditorComponent, {
+			propsData: {
+				config: {
+					delayIfDetached_callback: finishCreation => {
+						fcreat = finishCreation;
+					}
+				}
+			},
+			attachTo: mountTarget
+		} );
+		// const component = wrapper.vm.$children[ 0 ];
+
+		return delay( 100, () => {
+			// Editor is created after namespace loads
+			// so we need to wait for the real results
+			expect( wrapper.vm.instance ).to.be.null;
+		} ).then( () => {
+			document.body.appendChild( parent );
+			fcreat();
 		} ).then( () => {
 			return delay( 1000, () => {
 				expect( wrapper.vm.instance ).to.be.not.null;

--- a/tests/component.js
+++ b/tests/component.js
@@ -3,11 +3,14 @@
  * For licensing, see LICENSE.md.
  */
 
+import 'core-js/es/object/entries';
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import CKEditorComponent from '../src/ckeditor';
 import sinon from 'sinon';
 import { getEditorNamespace } from 'ckeditor4-integrations-common';
+
+import { deleteCkeditorScripts } from './utils';
 
 /* global window, document */
 
@@ -409,10 +412,14 @@ describe( 'CKEditor Component', () => {
 } );
 
 describe( 'comp on detach elem', () => {
-	let wrapper;
+	let wrapperr;
 
 	afterEach( () => {
-		wrapper.destroy();
+		wrapperr.destroy();
+	} );
+
+	after( () => {
+		return deleteCkeditorScripts();
 	} );
 
 	it( 'tries to mount component on detached element and use default interval strategy before creates', () => {
@@ -421,20 +428,17 @@ describe( 'comp on detach elem', () => {
 		const mountTarget = document.createElement( 'div' );
 		parent.appendChild( mountTarget );
 
-		wrapper = mount( CKEditorComponent, {
-			propsData: {},
-			attachTo: mountTarget
-		} );
+		wrapperr = createComponent( {}, mountTarget );
 
 		return delay( 100, () => {
 			// Editor is created after namespace loads
 			// so we need to wait for the real results
-			expect( wrapper.vm.instance ).to.be.null;
+			expect( wrapperr.vm.instance ).to.be.null;
 		} ).then( () => {
 			document.body.appendChild( parent );
 		} ).then( () => {
 			return delay( 1000, () => {
-				expect( wrapper.vm.instance ).to.be.not.null;
+				expect( wrapperr.vm.instance ).to.be.not.null;
 			} );
 		} );
 	} );
@@ -446,27 +450,27 @@ describe( 'comp on detach elem', () => {
 		parent.appendChild( mountTarget );
 		let createEditor;
 
-		wrapper = mount( CKEditorComponent, {
-			propsData: {
+		wrapperr = createComponent(
+			{
 				config: {
 					delayIfDetached_callback: finishCreation => {
 						createEditor = finishCreation;
 					}
 				}
 			},
-			attachTo: mountTarget
-		} );
+			mountTarget
+		);
 
 		return delay( 100, () => {
 			// Editor is created after namespace loads
 			// so we need to wait for the real results
-			expect( wrapper.vm.instance ).to.be.null;
+			expect( wrapperr.vm.instance ).to.be.null;
 		} ).then( () => {
 			document.body.appendChild( parent );
 			createEditor();
 		} ).then( () => {
 			return delay( 1000, () => {
-				expect( wrapper.vm.instance ).to.be.not.null;
+				expect( wrapperr.vm.instance ).to.be.not.null;
 			} );
 		} );
 	} );
@@ -481,7 +485,7 @@ function delay( time, func = () => {} ) {
 	} );
 }
 
-function createComponent( props ) {
+function createComponent( props, mountTarget = document.body ) {
 	const fakeParent = window.document.createElement( 'span' );
 
 	props = { ...props };
@@ -494,6 +498,6 @@ function createComponent( props ) {
 
 	return mount( CKEditorComponent, {
 		propsData: props,
-		attachTo: document.body
+		attachTo: mountTarget
 	} );
 }

--- a/tests/component.js
+++ b/tests/component.js
@@ -415,11 +415,12 @@ describe( 'comp on detach elem', () => {
 	sandbox.spy( cken, 'replace' );
 
 	afterEach( () => {
-		// wrapper.destroy();
+		wrapper.destroy();
 		sandbox.restore();
 	} );
 	it( 'tries to mount component on detached element and use default interval strategy before creates', () => {
 		const parent = document.createElement( 'div' );
+		// Vue will replace mount target, so we have extra parent to manipulate it.
 		const mountTarget = document.createElement( 'div' );
 		parent.appendChild( mountTarget );
 

--- a/tests/component.js
+++ b/tests/component.js
@@ -11,7 +11,7 @@ import { getEditorNamespace } from 'ckeditor4-integrations-common';
 
 /* global window, document */
 
-describe.skip( 'CKEditor Component', () => {
+describe( 'CKEditor Component', () => {
 	const CKEditorNamespace = window.CKEDITOR;
 
 	let skipReady = false;
@@ -410,13 +410,9 @@ describe.skip( 'CKEditor Component', () => {
 
 describe( 'comp on detach elem', () => {
 	let wrapper;
-	// const cken = window.CKEDITOR;
-	// const sandbox = sinon.createSandbox();
-	// sandbox.spy( cken, 'replace' );
 
 	afterEach( () => {
 		wrapper.destroy();
-		// sandbox.restore();
 	} );
 
 	it( 'tries to mount component on detached element and use default interval strategy before creates', () => {
@@ -429,7 +425,6 @@ describe( 'comp on detach elem', () => {
 			propsData: {},
 			attachTo: mountTarget
 		} );
-		// const component = wrapper.vm.$children[ 0 ];
 
 		return delay( 100, () => {
 			// Editor is created after namespace loads
@@ -449,18 +444,18 @@ describe( 'comp on detach elem', () => {
 		// Vue will replace mount target, so we have extra parent to manipulate it.
 		const mountTarget = document.createElement( 'div' );
 		parent.appendChild( mountTarget );
-		let fcreat;
+		let createEditor;
+
 		wrapper = mount( CKEditorComponent, {
 			propsData: {
 				config: {
 					delayIfDetached_callback: finishCreation => {
-						fcreat = finishCreation;
+						createEditor = finishCreation;
 					}
 				}
 			},
 			attachTo: mountTarget
 		} );
-		// const component = wrapper.vm.$children[ 0 ];
 
 		return delay( 100, () => {
 			// Editor is created after namespace loads
@@ -468,7 +463,7 @@ describe( 'comp on detach elem', () => {
 			expect( wrapper.vm.instance ).to.be.null;
 		} ).then( () => {
 			document.body.appendChild( parent );
-			fcreat();
+			createEditor();
 		} ).then( () => {
 			return delay( 1000, () => {
 				expect( wrapper.vm.instance ).to.be.not.null;
@@ -485,6 +480,7 @@ function delay( time, func = () => {} ) {
 		}, time );
 	} );
 }
+
 function createComponent( props ) {
 	const fakeParent = window.document.createElement( 'span' );
 

--- a/tests/component.js
+++ b/tests/component.js
@@ -409,7 +409,7 @@ describe( 'CKEditor Component', () => {
 
 		return mount( CKEditorComponent, {
 			propsData: props,
-			attachToDocument: true
+			attachTo: document.body
 		} );
 	}
 

--- a/tests/component.js
+++ b/tests/component.js
@@ -413,11 +413,11 @@ describe( 'CKEditor Component', () => {
 	}
 } );
 
-describe( 'comp on detach elem', () => {
-	let wrapperr;
+describe( 'component on detached element', () => {
+	let wrapper;
 
 	afterEach( () => {
-		wrapperr.destroy();
+		wrapper.destroy();
 	} );
 
 	after( () => {
@@ -430,17 +430,17 @@ describe( 'comp on detach elem', () => {
 		const mountTarget = document.createElement( 'div' );
 		parent.appendChild( mountTarget );
 
-		wrapperr = createComponent( {}, mountTarget );
+		wrapper = createComponent( {}, mountTarget );
 
 		return delay( 100, () => {
 			// Editor is created after namespace loads
 			// so we need to wait for the real results
-			expect( wrapperr.vm.instance ).to.be.undefined;
+			expect( wrapper.vm.instance ).to.be.undefined;
 		} ).then( () => {
 			document.body.appendChild( parent );
 		} ).then( () => {
 			return delay( 1000, () => {
-				expect( wrapperr.vm.instance ).to.be.not.null;
+				expect( wrapper.vm.instance ).to.be.not.null;
 			} );
 		} );
 	} );
@@ -452,7 +452,7 @@ describe( 'comp on detach elem', () => {
 		parent.appendChild( mountTarget );
 		let createEditor;
 
-		wrapperr = createComponent(
+		wrapper = createComponent(
 			{
 				config: {
 					delayIfDetached_callback: finishCreation => {
@@ -466,13 +466,13 @@ describe( 'comp on detach elem', () => {
 		return delay( 100, () => {
 			// Editor is created after namespace loads
 			// so we need to wait for the real results
-			expect( wrapperr.vm.instance ).to.be.undefined;
+			expect( wrapper.vm.instance ).to.be.undefined;
 		} ).then( () => {
 			document.body.appendChild( parent );
 			createEditor();
 		} ).then( () => {
 			return delay( 1000, () => {
-				expect( wrapperr.vm.instance ).to.be.not.null;
+				expect( wrapper.vm.instance ).to.be.not.null;
 			} );
 		} );
 	} );

--- a/tests/component.js
+++ b/tests/component.js
@@ -383,6 +383,7 @@ describe( 'CKEditor Component', () => {
 			beforeEach( () => {
 				spy = sandbox.spy( component.instance, method );
 				wrapper.setProps( { [ property ]: value } );
+				return Vue.nextTick();
 			} );
 
 			it( `${ spyCalled ? 'should' : 'shouldn\'t' } call "instance.${ method }"`, () => {

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -3,6 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
+// VTU use entries, which fails for IE11
 import 'core-js/es/object/entries';
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -3,9 +3,11 @@
  * For licensing, see LICENSE.md.
  */
 
+import 'core-js/es/object/entries';
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import CKEditor from '../src/index';
+import { deleteCkeditorScripts } from './utils';
 
 /* global window, document */
 
@@ -23,7 +25,7 @@ describe( 'Integration of CKEditor component', () => {
 			wrapper.destroy();
 		}
 
-		deleteCkeditorScripts();
+		return deleteCkeditorScripts();
 	} );
 
 	it( 'should initialize classic editor', () => {
@@ -85,19 +87,19 @@ describe( 'Integration of CKEditor component', () => {
 	it( 'should use correct CKEDITOR build', () => {
 		const basePath = 'https://cdn.ckeditor.com/4.13.0/standard-all/';
 
-		return createComponent( { editorUrl: basePath + 'ckeditor.js' } ).then( ( comp ) => {
+		return createComponent( { editorUrl: basePath + 'ckeditor.js' } ).then( comp => {
 			expect( window.CKEDITOR.basePath ).to.equal( basePath );
 		} );
 	} );
 
 	// Because of lack of `observableParent` config option - this test needs to be at the end (#124)
-	it( 'should initialize classic editor with default config', () => {
-		return mountComponent( {} ).then( component => {
-			const editor = component.instance;
+	// it( 'should initialize classic editor with default config', () => {
+	// 	return mountComponent( {} ).then( component => {
+	// 		const editor = component.instance;
 
-			expect( editor.getData() ).to.equal( '<p><strong>foo</strong></p>\n' );
-		} );
-	} );
+	// 		expect( editor.getData() ).to.equal( '<p><strong>foo</strong></p>\n' );
+	// 	} );
+	// } );
 
 	function createComponent( props = {}, namespaceLoaded = ( () => {} ) ) {
 		const fakeParent = window.document.createElement( 'span' );
@@ -153,15 +155,5 @@ describe( 'Integration of CKEditor component', () => {
 		}
 
 		return propsValue;
-	}
-
-	function deleteCkeditorScripts() {
-		const scripts = Array.from( document.querySelectorAll( 'script' ) );
-		const ckeditorScripts = scripts.filter( scriptElement => {
-			return scriptElement.src.indexOf( 'ckeditor.js' ) > -1;
-		} );
-		ckeditorScripts.forEach( x => x.parentNode.removeChild( x ) );
-
-		delete window.CKEDITOR;
 	}
 } );

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -7,7 +7,7 @@ import 'core-js/es/object/entries';
 import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import CKEditor from '../src/index';
-import { deleteCkeditorScripts } from './utils';
+import { delay, deleteCkeditorScripts } from './utils';
 
 /* global window, document */
 
@@ -93,26 +93,30 @@ describe( 'Integration of CKEditor component', () => {
 	} );
 
 	// Because of lack of `observableParent` config option - this test needs to be at the end (#124)
-	// it( 'should initialize classic editor with default config', () => {
-	// 	return mountComponent( {} ).then( component => {
-	// 		const editor = component.instance;
+	it( 'should initialize classic editor with default config', () => {
+		return mountComponent( {} ).then( component => {
+			const editor = component.instance;
 
-	// 		expect( editor.getData() ).to.equal( '<p><strong>foo</strong></p>\n' );
-	// 	} );
-	// } );
+			expect( editor.getData() ).to.equal( '<p><strong>foo</strong></p>\n' );
+			// Let's disconnect the observer in the CKE4 instance
+			return delay( 100, () => {
+				editor.setMode( 'source' );
+			} );
+		} );
+	} );
 
 	function createComponent( props = {}, namespaceLoaded = ( () => {} ) ) {
 		const fakeParent = window.document.createElement( 'span' );
 		return mountComponent(
 			props,
+			namespaceLoaded,
 			{
 				observableParent: fakeParent
-			},
-			namespaceLoaded
+			}
 		);
 	}
 
-	function mountComponent( props = {}, config, namespaceLoaded = ( () => {} ) ) {
+	function mountComponent( props = {}, namespaceLoaded = ( () => {} ), config ) {
 		return new Promise( resolve => {
 			props = propsToString( props );
 

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -123,7 +123,7 @@ describe( 'Integration of CKEditor component', () => {
 					${ props }
 				></ckeditor>`
 			}, {
-				attachToDocument: true,
+				attachTo: document.body,
 				methods: {
 					namespaceLoaded
 				},

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -98,10 +98,11 @@ describe( 'Integration of CKEditor component', () => {
 			const editor = component.instance;
 
 			expect( editor.getData() ).to.equal( '<p><strong>foo</strong></p>\n' );
+
 			// Let's disconnect the observer in the CKE4 instance
-			return delay( 100, () => {
-				editor.setMode( 'source' );
-			} );
+			editor.setMode( 'source' );
+			// And wait for the effects before test case ends
+			return delay( 500 );
 		} );
 	} );
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -13,3 +13,12 @@ export function deleteCkeditorScripts() {
 		}, 1000 );
 	} );
 }
+
+export function delay( time, func = () => {} ) {
+	return new Promise( res => {
+		setTimeout( () => {
+			func();
+			res();
+		}, time );
+	} );
+}

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -9,7 +9,6 @@ export function deleteCkeditorScripts() {
 			ckeditorScripts.forEach( x => x.parentNode.removeChild( x ) );
 
 			delete window.CKEDITOR;
-			console.log( '3 AFTER NAMESPACE deleted' );
 			res();
 		}, 1000 );
 	} );

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,24 +1,22 @@
 export function deleteCkeditorScripts() {
 	// Give CKE4 some time for destroy actions
-	return new Promise( res => {
-		setTimeout( () => {
-			const scripts = Array.from( document.querySelectorAll( 'script' ) );
-			const ckeditorScripts = scripts.filter( scriptElement => {
-				return scriptElement.src.indexOf( 'ckeditor.js' ) > -1;
-			} );
-			ckeditorScripts.forEach( x => x.parentNode.removeChild( x ) );
+	return delay( 1000, () => {
+		const scripts = Array.from( document.querySelectorAll( 'script' ) );
+		const ckeditorScripts = scripts.filter( scriptElement => {
+			return scriptElement.src.indexOf( 'ckeditor.js' ) > -1;
+		} );
 
-			delete window.CKEDITOR;
-			res();
-		}, 1000 );
+		ckeditorScripts.forEach( x => x.parentNode.removeChild( x ) );
+
+		delete window.CKEDITOR;
 	} );
 }
 
 export function delay( time, func = () => {} ) {
-	return new Promise( res => {
+	return new Promise( resolve => {
 		setTimeout( () => {
 			func();
-			res();
+			resolve();
 		}, time );
 	} );
 }

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,3 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
 export function deleteCkeditorScripts() {
 	// Give CKE4 some time for destroy actions
 	return delay( 1000, () => {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,16 @@
+export function deleteCkeditorScripts() {
+	// Give CKE4 some time for destroy actions
+	return new Promise( res => {
+		setTimeout( () => {
+			const scripts = Array.from( document.querySelectorAll( 'script' ) );
+			const ckeditorScripts = scripts.filter( scriptElement => {
+				return scriptElement.src.indexOf( 'ckeditor.js' ) > -1;
+			} );
+			ckeditorScripts.forEach( x => x.parentNode.removeChild( x ) );
+
+			delete window.CKEDITOR;
+			console.log( '3 AFTER NAMESPACE deleted' );
+			res();
+		}, 1000 );
+	} );
+}


### PR DESCRIPTION
Bump `vue testing utility`. It is no longer in the beta version. The newest version contains options for `mount` testing method which is useful in this case: https://vue-test-utils.vuejs.org/api/options.html#attachto

Adjust the component to use the new default config value. It requires moving editor inner instance initialization to the instanceReady event. Since with the delayIfDetach config options, it is possible that core `replace` or `inline` methods return `null` instead of editor instance. 

Split `mounted` component logic onto separate methods - since preparing config for the editor is more complicated now.

Add safari launcher since BS Safari often ends with timeout errors. So it is possible to use safari in karma config on your local machine. However, I didn't modify the config.

As for the tests workflow. Hopefully, I was able to separate tests and test cases from each other. I have to make an ugly hack for the test with an empty editor config since I can't set there a fake `observableParent`. MutationObserver is disconnected while the editor switch mode, so I used that. But because of those problems, I made a follow up:

Currently, we are destroying the wrapper for the CKE4, however, we may destroy the editor first, and then clean up the wrapper. Currently, it makes no difference, but I've made a follow up: https://github.com/ckeditor/ckeditor4/issues/5004

Extracted two functions in tests to util file.

Also, test changes may be a good introduction to https://github.com/ckeditor/ckeditor4-vue/issues/6 However - I feel like we need to put more effort to test refactoring.

Closes #102 , #86 